### PR TITLE
fix: Ensure Google Chrome context menu launches correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,9 @@ RUN \
 # add local files
 COPY /root /
 
+# Create symlink for backward compatibility or unexpected calls
+RUN ln -s /usr/bin/wrapped-browser /usr/bin/wrapped-chromium
+
 # ports and volumes
 EXPOSE 3000
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -41,6 +41,9 @@ RUN \
 # add local files
 COPY /root /
 
+# Create symlink for backward compatibility or unexpected calls
+RUN ln -s /usr/bin/wrapped-browser /usr/bin/wrapped-chromium
+
 # ports and volumes
 EXPOSE 3000
 

--- a/root/defaults/autostart
+++ b/root/defaults/autostart
@@ -1,2 +1,3 @@
 #!/bin/bash
-wrapped-chromium ${CHROME_CLI}
+openbox --reconfigure &
+wrapped-browser ${CHROME_CLI}


### PR DESCRIPTION
This commit addresses an issue where the context menu was reportedly still attempting to launch the old `wrapped-chromium` script, leading to an error.

Corrective actions include:
- Modified `root/defaults/autostart`:
    - Updated to call `wrapped-browser` instead of `wrapped-chromium`.
    - Added `openbox --reconfigure &` at the beginning to ensure menu configurations are reloaded when the session starts.
- Added a symbolic link in the Dockerfiles:
    - `ln -s /usr/bin/wrapped-browser /usr/bin/wrapped-chromium`
    - This acts as a failsafe in case any component still tries to call the old script name directly.

These changes, combined with the previous replacement of Chromium with Google Chrome, aim to ensure the context menu reliably launches Google Chrome.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [ ] I have read the [contributing](https://github.com/linuxserver/docker-chromium/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
